### PR TITLE
End to end test

### DIFF
--- a/src/main/java/models/igp/IGPPrefix.java
+++ b/src/main/java/models/igp/IGPPrefix.java
@@ -3,8 +3,4 @@ package models.igp;
 import util.Attribute;
 
 public class IGPPrefix {
-    public Attribute attributes;
-    public void setAttributes(Attribute attributes) {
-        this.attributes = attributes;
-    }
 }

--- a/src/main/java/models/igp/RoutingGraph.java
+++ b/src/main/java/models/igp/RoutingGraph.java
@@ -20,7 +20,7 @@ public abstract class RoutingGraph {
     }
 
     public abstract void addNode(String nodeId);
-    public abstract void addEdge(String srcId, InetAddress srcAddress, String destId, InetAddress destAddress, Float metric);
+    public abstract void addEdge(String srcId, InetAddress srcAddress, String destId, InetAddress destAddress, float metric);
     public abstract void removeNode(String nodeId);
     public abstract void removeEdge(String srcId, String destId);
 }

--- a/src/main/java/models/igp/ospf/OSPFArea.java
+++ b/src/main/java/models/igp/ospf/OSPFArea.java
@@ -44,6 +44,7 @@ public class OSPFArea extends RoutingGraph {
 
         // Add edges
         edges.putIfAbsent(srcId, new HashSet<>());
+        edges.putIfAbsent(destId, new HashSet<>());
         Set<String> neighbors = edges.get(srcId);
         neighbors.add(destId);
 

--- a/src/main/java/models/igp/ospf/OSPFArea.java
+++ b/src/main/java/models/igp/ospf/OSPFArea.java
@@ -27,7 +27,7 @@ public class OSPFArea extends RoutingGraph {
     }
 
     @Override
-    public void addEdge(String srcId, InetAddress srcAddress, String destId, InetAddress destAddress, Float metric) {
+    public void addEdge(String srcId, InetAddress srcAddress, String destId, InetAddress destAddress, float metric) {
         assert(nodesToInterfaces.containsKey(srcId));
         assert(nodesToInterfaces.containsKey(destId));
 
@@ -49,6 +49,7 @@ public class OSPFArea extends RoutingGraph {
 
         // Add metric
         edgeCosts.putIfAbsent(srcIp, new HashMap<>());
+        edgeCosts.putIfAbsent(destIp, new HashMap<>());
         Map<String, Float> costs = edgeCosts.get(srcIp);
         costs.put(destIp, metric);
     }

--- a/src/main/java/models/igp/ospf/OSPFInstance.java
+++ b/src/main/java/models/igp/ospf/OSPFInstance.java
@@ -125,7 +125,7 @@ public class OSPFInstance extends IGPInstance {
 
         String routerId = nlri.local.routerId;
         // Keeping track of connected routers and connection attributes of the prefix
-        prefix.attributesForRouter.put(routerId, attributes);
+        prefix.addRouter(routerId, attributes);
 
         // Keeping track of reachable prefixes in routerId
         OSPFRouter router = routers.get(routerId);
@@ -157,7 +157,7 @@ public class OSPFInstance extends IGPInstance {
     private void removePrefix(String prefixStr, String routerId) {
         // go into prefix to remove router
         OSPFPrefix prefix = prefixes.get(prefixStr);
-        prefix.attributesForRouter.remove(routerId);
+        prefix.removeRouter(routerId);
         routers.get(routerId).removeReachablePrefix(prefixStr);
         prefixTrie.delete(prefixStr);
     }

--- a/src/main/java/models/igp/ospf/OSPFPrefix.java
+++ b/src/main/java/models/igp/ospf/OSPFPrefix.java
@@ -12,4 +12,12 @@ public class OSPFPrefix extends IGPPrefix {
     public OSPFPrefix(){
         attributesForRouter = new HashMap<>();
     }
+
+    public void addRouter(String routerId, Attribute attribute){
+        attributesForRouter.put(routerId, attribute);
+    }
+
+    public void removeRouter(String routerId){
+        attributesForRouter.remove(routerId);
+    }
 }

--- a/src/main/java/models/igp/ospf/OSPFPrefix.java
+++ b/src/main/java/models/igp/ospf/OSPFPrefix.java
@@ -3,6 +3,7 @@ package models.igp.ospf;
 import models.igp.IGPPrefix;
 
 import java.util.*;
+import util.Attribute;
 
 public class OSPFPrefix extends IGPPrefix {
     // routerId => attribute

--- a/src/main/java/models/igp/ospf/OSPFPrefix.java
+++ b/src/main/java/models/igp/ospf/OSPFPrefix.java
@@ -2,17 +2,13 @@ package models.igp.ospf;
 
 import models.igp.IGPPrefix;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class OSPFPrefix extends IGPPrefix {
-    public Set<String> routerIds;
+    // routerId => attribute
+    public HashMap<String, Attribute> attributesForRouter;
 
-    public OSPFPrefix() {
-        this.routerIds = new HashSet<>();
-    }
-
-    public void addRouter(String routerId) {
-        routerIds.add(routerId);
+    public OSPFPrefix(){
+        attributesForRouter = new HashMap<>();
     }
 }

--- a/src/main/java/models/igp/ospf/OSPFRouter.java
+++ b/src/main/java/models/igp/ospf/OSPFRouter.java
@@ -22,4 +22,8 @@ public class OSPFRouter extends IGPNode {
     public void addReachablePrefix(String prefix) {
         this.reachablePrefixes.add(prefix);
     }
+
+    public void removeReachablePrefix(String prefix) {
+        this.reachablePrefixes.remove(prefix);
+    }
 }

--- a/src/main/java/models/igp/ospf/OSPFRouter.java
+++ b/src/main/java/models/igp/ospf/OSPFRouter.java
@@ -7,12 +7,12 @@ import java.util.*;
 
 public class OSPFRouter extends IGPNode {
     public Set<String> areaIds;
-    public List<String> reachablePrefixes;
+    public Set<String> reachablePrefixes;
 
     public OSPFRouter(String routerId) {
         super(routerId);
-        this.areaIds = new HashSet();
-        this.reachablePrefixes = new ArrayList<>();
+        this.areaIds = new HashSet<>();
+        this.reachablePrefixes = new HashSet<>();
     }
 
     public void addArea(String areaId) {

--- a/src/main/java/models/igp/ospf/PrefixTrie.java
+++ b/src/main/java/models/igp/ospf/PrefixTrie.java
@@ -3,7 +3,7 @@ package models.igp.ospf;
 import models.igp.ospf.TrieNode;
 
 import java.util.*;
-class PrefixTrie {
+public class PrefixTrie {
     private final TrieNode root;
 
     public PrefixTrie() {

--- a/src/main/java/models/igp/ospf/PrefixTrie.java
+++ b/src/main/java/models/igp/ospf/PrefixTrie.java
@@ -1,3 +1,7 @@
+package models.igp.ospf;
+
+import models.igp.ospf.TrieNode;
+
 import java.util.*;
 class PrefixTrie {
     private final TrieNode root;

--- a/src/main/java/models/igp/ospf/TrieNode.java
+++ b/src/main/java/models/igp/ospf/TrieNode.java
@@ -1,3 +1,5 @@
+package models.igp.ospf;
+
 class TrieNode {
     private final String bitString;
     private final int level;

--- a/src/test/java/EndToEndTest.java
+++ b/src/test/java/EndToEndTest.java
@@ -1,0 +1,82 @@
+import models.Topologies;
+import models.bgpls.NLRI;
+import models.bgpls.UpdateMessage;
+import models.igp.IGPInstance;
+import models.igp.ospf.*;
+import parser.exabgp.ExabgpParser;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EndToEndTest {
+
+    @Test
+    public void BuildOSPFTopologyTest(){
+        String resourceName = "dummydata/bgpls-examples.json";
+        InputStream inputStream = Main.class.getClassLoader().getResourceAsStream(resourceName);
+
+        ExabgpParser parser = new ExabgpParser();
+        Topologies topologies = new Topologies();
+        try {
+            List<UpdateMessage> messages = parser.readMessage(inputStream);
+            for (UpdateMessage message : messages) {
+                for (NLRI nlri : message.nlris) {
+                    IGPInstance topology = topologies.get(
+                            nlri.getBgplsId(),
+                            nlri.getAs(),
+                            nlri.protocolId,
+                            nlri.instanceId
+                    );
+
+                    if (topology == null) {
+                        topology = new OSPFInstance();
+                        topologies.add(
+                                nlri.getBgplsId(),
+                                nlri.getAs(),
+                                nlri.protocolId,
+                                nlri.instanceId,
+                                topology
+                        );
+                    }
+
+                    topology.handleNLRI(message.attributes, nlri);
+                }
+            }
+            assertEquals(1, topologies.size());
+            OSPFInstance ospfInstance = (OSPFInstance) topologies.get("0", 65530, 3, 0);
+
+            // print areas, nodes, links detail
+            int linkCount = 0;
+            for (String areaId : ospfInstance.subgraphs.keySet()){
+                OSPFArea area = ospfInstance.subgraphs.get(areaId);
+                assertEquals(areaId, area.areaId);
+                System.out.println("Area: " + areaId + ": " + area.nodesToInterfaces.keySet().size() + " routers ");
+                for (String routerId : area.nodesToInterfaces.keySet()){
+                    Set<String> interfaces = area.nodesToInterfaces.get(routerId);
+                    System.out.println("    Router " + routerId +
+                            ": interfaces " + interfaces);
+                    for (String srcInterface : interfaces){
+                        for (String dstInterface : area.edgeCosts.get(srcInterface).keySet()){
+                            System.out.println("        Edge: " + srcInterface + " -> " +
+                                    dstInterface + ": cost " + area.edgeCosts.get(srcInterface).get(dstInterface));
+                            linkCount++;
+                        }
+                    }
+                }
+            }
+
+            // link information
+            System.out.println("Number of links: " + ospfInstance.links.keySet().size());
+            assertEquals(linkCount, ospfInstance.links.keySet().size());
+
+
+        } catch (IOException e) {
+            System.out.println("RIP");
+        }
+    }
+}

--- a/src/test/java/EndToEndTest.java
+++ b/src/test/java/EndToEndTest.java
@@ -67,6 +67,8 @@ public class EndToEndTest {
                             linkCount++;
                         }
                     }
+                    OSPFRouter router = ospfInstance.routers.get(routerId);
+                    System.out.println("        Reachable prefix: " + router.reachablePrefixes);
                 }
             }
 
@@ -74,6 +76,26 @@ public class EndToEndTest {
             System.out.println("Number of links: " + ospfInstance.links.keySet().size());
             assertEquals(linkCount, ospfInstance.links.keySet().size());
 
+            System.out.println("======================================");
+
+            // prefix reachability
+            for (String prefixStr : ospfInstance.prefixes.keySet()){
+                System.out.println("Prefix: " + prefixStr);
+                OSPFPrefix prefix = ospfInstance.prefixes.get(prefixStr);
+                for (String routerId : prefix.attributesForRouter.keySet()){
+                    System.out.println("    Router " + routerId + ": " +
+                            prefix.attributesForRouter.get(routerId).get("prefix-metric"));
+                }
+            }
+
+            // test prefix trie
+            // make sure all prefixes are inside the trie
+            for (String prefixStr : ospfInstance.prefixes.keySet()){
+                assertEquals(prefixStr, ospfInstance.prefixTrie.longestMatch(prefixStr));
+            }
+            assertEquals("10.0.0.48/30", ospfInstance.prefixTrie.longestMatch("10.0.0.48/32"));
+            assertEquals("192.168.0.3/32", ospfInstance.prefixTrie.longestMatch("192.168.0.3/32"));
+            assertEquals("192.168.1.0/24", ospfInstance.prefixTrie.longestMatch("192.168.1.0/30"));
 
         } catch (IOException e) {
             System.out.println("RIP");

--- a/src/test/java/EndToEndTest.java
+++ b/src/test/java/EndToEndTest.java
@@ -96,6 +96,7 @@ public class EndToEndTest {
             assertEquals("10.0.0.48/30", ospfInstance.prefixTrie.longestMatch("10.0.0.48/32"));
             assertEquals("192.168.0.3/32", ospfInstance.prefixTrie.longestMatch("192.168.0.3/32"));
             assertEquals("192.168.1.0/24", ospfInstance.prefixTrie.longestMatch("192.168.1.0/30"));
+            assertEquals("", ospfInstance.prefixTrie.longestMatch("10.0.0.0/32"));
 
         } catch (IOException e) {
             System.out.println("RIP");

--- a/src/test/java/models/igp/ospf/OSPFInstanceTest.java
+++ b/src/test/java/models/igp/ospf/OSPFInstanceTest.java
@@ -70,10 +70,4 @@ public class OSPFInstanceTest {
         assert(ospfTopology.prefixes.size() == 1);
 
     }
-
-    @Test
-    public void testBuildPrefixTrie(){
-
-    }
-
 }

--- a/src/test/java/models/igp/ospf/OSPFInstanceTest.java
+++ b/src/test/java/models/igp/ospf/OSPFInstanceTest.java
@@ -70,4 +70,10 @@ public class OSPFInstanceTest {
         assert(ospfTopology.prefixes.size() == 1);
 
     }
+
+    @Test
+    public void testBuildPrefixTrie(){
+
+    }
+
 }

--- a/src/test/java/models/igp/ospf/PrefixTrieTest.java
+++ b/src/test/java/models/igp/ospf/PrefixTrieTest.java
@@ -1,3 +1,6 @@
+package models.igp.ospf;
+
+import models.igp.ospf.PrefixTrie;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
Wrote and passed end-to-end test that prints network topology and checks that the prefix Trie works properly.
Output from dummy data:
```
Area: 0.0.0.0: 5 routers 
    Router 192.168.0.2: interfaces [10.0.0.17, 10.0.0.6]
        Edge: 10.0.0.17 -> 10.0.0.18: cost 1.0
        Edge: 10.0.0.6 -> 10.0.0.5: cost 1.0
        Reachable prefix: [192.168.0.8/32, 192.168.0.4/32, 10.0.0.8/30, 192.168.0.6/32, 192.168.0.2/32, 10.0.1.0/30, 10.0.0.56/30, 10.0.1.4/30, 10.0.0.36/30, 10.0.0.52/30, 10.0.0.12/30, 10.0.0.64/30, 10.0.0.24/30, 10.0.0.28/30, 10.0.0.60/30, 10.0.0.20/30, 10.0.0.68/30, 192.168.0.5/32, 192.168.0.9/32, 192.168.0.7/32, 192.168.0.3/32, 10.0.0.16/30, 192.168.0.1/32, 10.0.0.32/30, 192.168.0.101/32, 10.0.0.4/30, 10.0.0.40/30, 192.168.0.12/32, 192.168.0.10/32, 10.0.0.48/30, 10.0.0.44/30]
    Router 192.168.0.1: interfaces [10.0.0.9, 10.0.0.5, 10.0.0.13]
        Edge: 10.0.0.9 -> 10.0.0.10: cost 1000.0
        Edge: 10.0.0.5 -> 10.0.0.6: cost 1.0
        Edge: 10.0.0.13 -> 10.0.0.14: cost 1.0
        Reachable prefix: [192.168.0.8/32, 192.168.0.4/32, 10.0.0.8/30, 192.168.0.6/32, 192.168.0.2/32, 10.0.1.0/30, 10.0.0.56/30, 10.0.1.4/30, 10.0.0.52/30, 10.0.0.36/30, 10.0.0.12/30, 10.0.0.64/30, 192.168.0.11/32, 10.0.0.24/30, 10.0.0.28/30, 10.0.0.60/30, 10.0.0.20/30, 10.0.0.68/30, 192.168.0.5/32, 192.168.0.9/32, 192.168.0.7/32, 192.168.0.3/32, 10.0.0.16/30, 192.168.0.1/32, 10.0.0.32/30, 192.168.0.101/32, 10.0.0.4/30, 10.0.0.40/30, 192.168.0.10/32, 10.0.0.48/30, 10.0.0.44/30]
    Router 192.168.0.4: interfaces [10.0.0.18, 10.0.0.14, 10.0.1.1, 10.0.0.22]
        Edge: 10.0.0.18 -> 10.0.0.17: cost 1.0
        Edge: 10.0.0.14 -> 10.0.0.13: cost 1.0
        Edge: 10.0.1.1 -> 10.0.1.2: cost 1.0
        Edge: 10.0.0.22 -> 10.0.0.21: cost 1.0
        Reachable prefix: [10.0.0.68/30, 10.0.0.20/30, 192.168.0.5/32, 192.168.0.4/32, 192.168.0.9/32, 192.168.0.6/32, 10.0.0.16/30, 10.0.1.0/30, 10.0.0.32/30, 10.0.0.12/30, 10.0.0.64/30, 192.168.0.10/32, 10.0.0.24/30, 10.0.0.60/30, 10.0.0.28/30]
    Router 192.168.0.3: interfaces [10.0.1.5, 10.0.0.10, 10.0.0.21]
        Edge: 10.0.1.5 -> 10.0.1.6: cost 1.0
        Edge: 10.0.0.10 -> 10.0.0.9: cost 1.0
        Edge: 10.0.0.21 -> 10.0.0.22: cost 1.0
        Reachable prefix: [10.0.0.68/30, 10.0.0.20/30, 192.168.0.5/32, 192.168.0.6/32, 192.168.0.9/32, 10.0.0.8/30, 192.168.0.3/32, 10.0.0.32/30, 10.0.1.4/30, 10.0.0.64/30, 192.168.0.10/32, 10.0.0.24/30, 10.0.0.28/30, 10.0.0.60/30]
    Router 192.168.0.101: interfaces [10.0.1.6, 10.0.1.2]
        Edge: 10.0.1.6 -> 10.0.1.5: cost 1.0
        Edge: 10.0.1.2 -> 10.0.1.1: cost 1.0
        Reachable prefix: [192.168.0.101/32, 10.0.1.0/30, 10.0.1.4/30]
Area: 0.0.0.1: 4 routers 
    Router 192.168.0.2: interfaces [10.0.0.49, 10.0.0.53]
        Edge: 10.0.0.49 -> 10.0.0.50: cost 1.0
        Edge: 10.0.0.53 -> 10.0.0.54: cost 1.0
        Reachable prefix: [192.168.0.8/32, 192.168.0.4/32, 10.0.0.8/30, 192.168.0.6/32, 192.168.0.2/32, 10.0.1.0/30, 10.0.0.56/30, 10.0.1.4/30, 10.0.0.36/30, 10.0.0.52/30, 10.0.0.12/30, 10.0.0.64/30, 10.0.0.24/30, 10.0.0.28/30, 10.0.0.60/30, 10.0.0.20/30, 10.0.0.68/30, 192.168.0.5/32, 192.168.0.9/32, 192.168.0.7/32, 192.168.0.3/32, 10.0.0.16/30, 192.168.0.1/32, 10.0.0.32/30, 192.168.0.101/32, 10.0.0.4/30, 10.0.0.40/30, 192.168.0.12/32, 192.168.0.10/32, 10.0.0.48/30, 10.0.0.44/30]
    Router 192.168.0.1: interfaces [10.0.0.37, 10.0.0.41]
        Edge: 10.0.0.37 -> 10.0.0.38: cost 1.0
        Edge: 10.0.0.41 -> 10.0.0.42: cost 1.0
        Reachable prefix: [192.168.0.8/32, 192.168.0.4/32, 10.0.0.8/30, 192.168.0.6/32, 192.168.0.2/32, 10.0.1.0/30, 10.0.0.56/30, 10.0.1.4/30, 10.0.0.52/30, 10.0.0.36/30, 10.0.0.12/30, 10.0.0.64/30, 192.168.0.11/32, 10.0.0.24/30, 10.0.0.28/30, 10.0.0.60/30, 10.0.0.20/30, 10.0.0.68/30, 192.168.0.5/32, 192.168.0.9/32, 192.168.0.7/32, 192.168.0.3/32, 10.0.0.16/30, 192.168.0.1/32, 10.0.0.32/30, 192.168.0.101/32, 10.0.0.4/30, 10.0.0.40/30, 192.168.0.10/32, 10.0.0.48/30, 10.0.0.44/30]
    Router 192.168.0.8: interfaces [10.0.0.54, 10.0.0.42]
        Edge: 10.0.0.54 -> 10.0.0.53: cost 1.0
        Edge: 10.0.0.42 -> 10.0.0.41: cost 1.0
        Reachable prefix: [192.168.0.8/32, 10.0.0.40/30, 10.0.0.52/30]
    Router 192.168.0.7: interfaces [10.0.0.50, 10.0.0.38]
        Edge: 10.0.0.50 -> 10.0.0.49: cost 1.0
        Edge: 10.0.0.38 -> 10.0.0.37: cost 1.0
        Reachable prefix: [192.168.2.0/24, 192.168.0.7/32, 10.0.0.48/30, 10.0.0.36/30]
Number of links: 22
======================================
Prefix: 192.168.0.8/32
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.8: 1
Prefix: 192.168.0.4/32
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.4: 1
Prefix: 10.0.0.8/30
    Router 192.168.0.2: 3
    Router 192.168.0.1: 1000
    Router 192.168.0.3: 1
Prefix: 192.168.0.6/32
    Router 192.168.0.2: 3
    Router 192.168.0.1: 3
    Router 192.168.0.4: 2
    Router 192.168.0.3: 3
Prefix: 192.168.2.0/24
    Router 192.168.0.7: 20
Prefix: 192.168.0.2/32
    Router 192.168.0.2: 1
    Router 192.168.0.1: 2
Prefix: 10.0.1.0/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.4: 1
    Router 192.168.0.101: 1
Prefix: 10.0.0.56/30
    Router 192.168.0.2: 1
    Router 192.168.0.1: 2
Prefix: 10.0.1.4/30
    Router 192.168.0.2: 3
    Router 192.168.0.1: 3
    Router 192.168.0.3: 1
    Router 192.168.0.101: 1
Prefix: 10.0.0.52/30
    Router 192.168.0.2: 1
    Router 192.168.0.1: 2
    Router 192.168.0.8: 1
Prefix: 10.0.0.36/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 1
    Router 192.168.0.7: 1
Prefix: 10.0.0.12/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 1
    Router 192.168.0.4: 1
Prefix: 192.168.1.0/24
    Router 192.168.0.9: 20
Prefix: 10.0.0.64/30
    Router 192.168.0.2: 3
    Router 192.168.0.1: 3
    Router 192.168.0.4: 2
    Router 192.168.0.3: 3
Prefix: 192.168.0.11/32
    Router 192.168.0.1: 20
Prefix: 10.0.0.24/30
    Router 192.168.0.2: 3
    Router 192.168.0.1: 3
    Router 192.168.0.4: 3
    Router 192.168.0.3: 1
Prefix: 10.0.0.60/30
    Router 192.168.0.2: 4
    Router 192.168.0.1: 4
    Router 192.168.0.4: 3
    Router 192.168.0.3: 2
Prefix: 10.0.0.28/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.4: 1
    Router 192.168.0.3: 3
Prefix: 10.0.0.68/30
    Router 192.168.0.2: 4
    Router 192.168.0.1: 4
    Router 192.168.0.4: 3
    Router 192.168.0.3: 3
Prefix: 10.0.0.20/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.4: 1
    Router 192.168.0.3: 1
Prefix: 192.168.0.5/32
    Router 192.168.0.2: 4
    Router 192.168.0.1: 4
    Router 192.168.0.4: 3
    Router 192.168.0.3: 2
Prefix: 192.168.0.9/32
    Router 192.168.0.2: 5
    Router 192.168.0.1: 5
    Router 192.168.0.4: 4
    Router 192.168.0.3: 3
Prefix: 192.168.0.7/32
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.7: 1
Prefix: 192.168.0.3/32
    Router 192.168.0.2: 3
    Router 192.168.0.1: 3
    Router 192.168.0.3: 1
Prefix: 10.0.0.16/30
    Router 192.168.0.2: 1
    Router 192.168.0.1: 2
    Router 192.168.0.4: 1
Prefix: 192.168.0.1/32
    Router 192.168.0.2: 2
    Router 192.168.0.1: 1
Prefix: 10.0.0.32/30
    Router 192.168.0.2: 3
    Router 192.168.0.1: 3
    Router 192.168.0.4: 2
    Router 192.168.0.3: 2
Prefix: 192.168.0.101/32
    Router 192.168.0.2: 2
    Router 192.168.0.1: 2
    Router 192.168.0.101: 0
Prefix: 10.0.0.4/30
    Router 192.168.0.2: 1
    Router 192.168.0.1: 1
Prefix: 10.0.0.40/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 1
    Router 192.168.0.8: 1
Prefix: 192.168.0.12/32
    Router 192.168.0.2: 20
Prefix: 192.168.0.10/32
    Router 192.168.0.2: 4
    Router 192.168.0.1: 4
    Router 192.168.0.4: 3
    Router 192.168.0.3: 4
Prefix: 10.0.0.48/30
    Router 192.168.0.2: 1
    Router 192.168.0.1: 2
    Router 192.168.0.7: 1
Prefix: 10.0.0.44/30
    Router 192.168.0.2: 2
    Router 192.168.0.1: 1
```